### PR TITLE
Add back branch_protection.yaml

### DIFF
--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,2 @@
+optConfig:
+  optIn: false


### PR DESCRIPTION
Set optIn to false.
The optIn option is used when an opt-in strategy is used at repo level.