### PR TITLE
Fix shellcheck warning

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-SCRIPT_DIR=$(dirname $0)
+SCRIPT_DIR=$(dirname "$0")
 
 # Where we run ./configure
 cd "${SCRIPT_DIR}/.."


### PR DESCRIPTION
Fix SC2086: Double quote to prevent globbing and word splitting