### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/build-libg2hec.yml
+++ b/.github/workflows/build-libg2hec.yml
@@ -29,5 +29,4 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           autoreconf -vi
-          ./scripts/install-ntl-5.5.sh
           ./scripts/build.sh 

--- a/.github/workflows/build-libg2hec.yml
+++ b/.github/workflows/build-libg2hec.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         compiler_c: [gcc, clang]
         compiler_cxx: [g++, clang++]
     steps:
@@ -19,9 +19,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y texinfo
-          sudo apt-get install -y autotools-dev autoconf build-essential
+          sudo apt update
+          sudo apt install -y texinfo
+          sudo apt install -y texlive-latex-extra
+          sudo apt install -y autotools-dev autoconf build-essential
       - name: Build
         env:
           CC: ${{ matrix.compiler_c }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,6 @@ jobs:
       run: |
         cd ${{ github.workspace }}
         autoreconf -vi
-        ./scripts/install-ntl-5.5.sh
         ./scripts/build.sh 
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         compiler_c: [gcc]
         compiler_cxx: [g++]
         language: [ 'cpp' ]

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         #compiler_c: [clang]
         #compiler_cxx: [clang++]
     steps:
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y texinfo
-          sudo apt-get install -y autotools-dev autoconf build-essential
+          sudo apt update
+          sudo apt install -y texinfo
+          sudo apt install -y autotools-dev autoconf build-essential
       - name: Publish docs
         #env:
         #  CC: ${{ matrix.compiler_c }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    paths-ignore:
+      - 'demo/**'
+    tags:
+      - 'v*'
+name: Release
+jobs:
+  release-tarball:
+    name: Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set RELEASE_VERSION as tag version
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo "$RELEASE_VERSION"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autotools-dev autoconf texinfo build-essential
+      - name: Build release tarball
+        run: |
+          autoreconf -vi
+          ./scripts/build.sh
+      - name: Release versioned
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "g2hec-lib-${{ env.RELEASE_VERSION}}.tar.gz"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -21,12 +21,14 @@ jobs:
           echo "$RELEASE_VERSION"
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y autotools-dev autoconf texinfo build-essential
+          sudo apt update
+          sudo apt install -y texinfo
+          sudo apt install -y texlive-latex-extra
+          sudo apt install -y autotools-dev autoconf build-essential
       - name: Build release tarball
         run: |
           autoreconf -vi
-          ./scripts/build.sh
+          ./scripts/build.sh distcheck
       - name: Release versioned
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,8 +23,8 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Install shellcheck on Ubuntu
         run: |
-          sudo apt-get update
-          sudo apt-get install shellcheck -y
+          sudo apt update
+          sudo apt install shellcheck -y
 
       - if: ${{ matrix.os == 'macos-latest' }}
         name: Install shellcheck on macos

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,3 +16,4 @@ examples_elgamal_sig_CXXFLAGS = -Iinclude/
 examples_elgamal_sig_LDADD = src/libg2hec.a -lntl
 examples_elgamal_sig_SOURCES = examples/elgamal_sig.C
 
+AM_DISTCHECK_DVI_TARGET = pdf

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The G2HEC library is released under the GNU Lesser General Public
 License Version 2.1.  See the file COPYING for details.
 
 ## How to build
+
 On Ubuntu,
 
 ```bash
@@ -48,17 +49,20 @@ $ cd libg2hec/
 $ sudo apt-get install autotools-dev autoconf texinfo build-essential
 # Bootstrap
 $ autoreconf -vi
-# Build NTL
-$ ./scripts/install-ntl-5.5.sh
-# Build libg2hec
+# Build NTL and libg2hec
 $ ./scripts/build.sh
 # Install libg2hec
 $ make install 
 ```
 
-This installs NTL and libg2hec (including documentation) in `/tmp/nssw/`
-by default. You may configure different paths in build scripts in
-`scripts/` for the installation.
+This installs NTL and libg2hec (including documentation) in a temporary
+directory by default (useful for CI testing). You may override the
+installation location using the `INSTALL_DIR_PREFIX` environment
+variable when calling `./script/build.sh`, e.g.,
+
+```bash
+INSTALL_DIR_PREFIX=/tmp/nssw ./script/build.sh
+```
 
 ## Documentation
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,11 +3,19 @@
 set -euxo pipefail
 
 SCRIPT_DIR=$(dirname "$0")
+FLAGS_TMPDIR=$(mktemp -d)
+readonly FLAGS_TMPDIR
 
-# Where we run ./configure
+# Where we run ./configure and NTL installation script
 cd "${SCRIPT_DIR}/.."
 
-env LDFLAGS=-L/tmp/nssw/lib CXXFLAGS=-I/tmp/nssw/include ./configure \
-    --prefix=/tmp/nssw
+# Install NTL
+scripts/install-ntl-5.5.sh "${FLAGS_TMPDIR}"
+
+env LDFLAGS="-L${FLAGS_TMPDIR}/lib" \
+    CXXFLAGS="-I${FLAGS_TMPDIR}/include" \
+    ./configure \
+    --prefix="${FLAGS_TMPDIR}"
 make
-make check
+make install
+DISTCHECK_CONFIGURE_FLAGS="LDFLAGS=-L${FLAGS_TMPDIR}/lib CXXFLAGS=-I${FLAGS_TMPDIR}/include" make distcheck

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,16 +6,22 @@ SCRIPT_DIR=$(dirname "$0")
 FLAGS_TMPDIR=$(mktemp -d)
 readonly FLAGS_TMPDIR
 
+INSTALL_DIR_PREFIX=${INSTALL_DIR_PREFIX:-${FLAGS_TMPDIR}}
+
 # Where we run ./configure and NTL installation script
 cd "${SCRIPT_DIR}/.."
 
 # Install NTL
-scripts/install-ntl-5.5.sh "${FLAGS_TMPDIR}"
+scripts/install-ntl-5.5.sh "${INSTALL_DIR_PREFIX}"
 
-env LDFLAGS="-L${FLAGS_TMPDIR}/lib" \
-    CXXFLAGS="-I${FLAGS_TMPDIR}/include" \
+env LDFLAGS="-L${INSTALL_DIR_PREFIX}/lib" \
+    CXXFLAGS="-I${INSTALL_DIR_PREFIX}/include" \
     ./configure \
-    --prefix="${FLAGS_TMPDIR}"
+    --prefix="${INSTALL_DIR_PREFIX}"
 make
-make install
-DISTCHECK_CONFIGURE_FLAGS="LDFLAGS=-L${FLAGS_TMPDIR}/lib CXXFLAGS=-I${FLAGS_TMPDIR}/include" make distcheck
+
+if [ "$#" -ge 1 ] && [ "$1" = "distcheck" ]; then
+  echo "Creating tarball for distribution"
+  make install
+  DISTCHECK_CONFIGURE_FLAGS="LDFLAGS=-L${INSTALL_DIR_PREFIX}/lib CXXFLAGS=-I${INSTALL_DIR_PREFIX}/include" make distcheck
+fi

--- a/scripts/install-ntl-5.5.sh
+++ b/scripts/install-ntl-5.5.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+INSTALL_DIR="$1"
+
 wget -c https://libntl.org/ntl-5.5.2.tar.gz -O /tmp/ntl.tar.gz
 tar xvfz /tmp/ntl.tar.gz -C /tmp/
 cd /tmp/ntl-5.5.2/src
-./configure PREFIX=/tmp/nssw
+./configure PREFIX="${INSTALL_DIR}"
 make
 make install


### PR DESCRIPTION
Add a workflow to publish release tarballs through Git tags.

The tags must follow the SEMVER format, and must match the version
specified in `AC_INIT` in "configure.ac".

We also refactored files in the "scripts/" directory for this to work.