### PR TITLE
GHA: Don't exit early when grepping piped output

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -37,7 +37,7 @@ jobs:
           cd ${{ github.workspace }}/
           shellcheck --version
           for f in $(find scripts/ -type f); do
-            if file "$f" | grep -q "shell script"; then
+            if file "$f" | grep "shell script" &>/dev/null; then
               shellcheck "$f"
             fi
           done


### PR DESCRIPTION
This is to avoid any potential broken pipe due to an early exit from grep.