### PR TITLE
GHA: Upgrade to actions/checkout v4.1.1

### DIFF
--- a/.github/workflows/clang-sa.yml
+++ b/.github/workflows/clang-sa.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,7 @@ jobs:
         #compiler_cxx: [clang++]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
       - name: Set RELEASE_VERSION as tag version
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -16,7 +16,7 @@ jobs:
         compiler_cxx: [g++, clang++]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
Move away from the deprecated node 12.